### PR TITLE
Don't use exact = TRUE in parse_date_time2

### DIFF
--- a/R/kntn_parse.R
+++ b/R/kntn_parse.R
@@ -77,7 +77,7 @@ kntn_parse_col <- function(x) {
 }
 
 kntn_parse_datetime <- function(x) {
-  lubridate::parse_date_time2(x, "YmdHMS", exact = TRUE)
+  lubridate::parse_date_time2(x, "YmdHMS")
 }
 
 kntn_wrap_with_list <- function(x) {


### PR DESCRIPTION
Due to a bug in lubridate `exact` argument wasn't used. In recent release the bug was fixed and your date-time is no longer parsed correctly. In your use case is should definitely be exact = FALSE. 

The problem was revealed during the rev-dep checks for CRAN submission:

```R

Loading kntnr
Testing kntnr
✔ |  OK F W S | Context
✖ |  11 1 1   | auth
────────────────────────────────────────────────────────────────────────────────────────────
test-auth.R:36: warning: kntn_set_auth raises error in noninteractive environment
At least one of KNTN_URL, KNTN_AUTH and KNTN_AUTH_TYPE is defined.
To overrite these, please rerun with 'overwrite = TRUE'


test-auth.R:36: failure: kntn_set_auth raises error in noninteractive environment
`kntn_set_auth()` did not throw an error.
────────────────────────────────────────────────────────────────────────────────────────────
✔ |   5       | calc_ranges
✔ |   1       | guess_url
✖ |  34 3     | parse
────────────────────────────────────────────────────────────────────────────────────────────
test-parse-field.R:14: failure: parsing CREATED_TIME works
x$test not equivalent to `expect`.
1/1 mismatches
[1] NA - 2015-01-22 15:07:00 == NA secs

test-parse-field.R:14: failure: parsing UPDATED_TIME works
x$test not equivalent to `expect`.
1/1 mismatches
[1] NA - 2015-01-22 15:07:00 == NA secs

test-parse-field.R:14: failure: parsing DATETIME works
x$test not equivalent to `expect`.
1/1 mismatches
[1] NA - 2015-03-17 10:20:00 == NA secs
────────────────────────────────────────────────────────────────────────────────────────────
✔ |  10       | kntn_parse and kntn_unnest
✔ |  10       | strip_query

══ Results ═════════════════════════════════════════════════════════════════════════════════
Duration: 0.2 s

OK:       71
Failed:   4
Warnings: 1
Skipped:  0
```

