### PR TITLE
Use tibble::as_tibble() to ensure the result is a tibble

### DIFF
--- a/R/kntn_parse.R
+++ b/R/kntn_parse.R
@@ -94,7 +94,8 @@ kntn_parse_multi_user <- function(x) {
 }
 
 kntn_parse_file <- function(x) {
-  purrr::map(x, dplyr::bind_rows)
+  x <- purrr::map(x, dplyr::bind_rows)
+  purrr::map(x, tibble::as_tibble)
 }
 
 kntn_parse_subtable <- function(x) {

--- a/R/kntn_record.R
+++ b/R/kntn_record.R
@@ -212,7 +212,11 @@ kntn_records <- function(app, fields = NULL, query = "",
     Sys.sleep(interval_time)
   }
 
-  if(as == "data.frame") dplyr::bind_rows(result) else result
+  if (identical(as, "data.frame")) {
+    tibble::as_tibble(dplyr::bind_rows(result))
+  } else {
+    result
+  }
 }
 
 kntn_stop_for_status <- function(res) {

--- a/tests/testthat/test-parse-field.R
+++ b/tests/testthat/test-parse-field.R
@@ -196,7 +196,7 @@ test_parse_field(
     ]
   }',
   function(x) {
-    is.list(x) && dplyr::is.tbl(x[[1]]) &&
+    is.list(x) && tibble::is_tibble(x[[1]]) &&
       identical(colnames(x[[1]]), c("contentType", "fileKey", "name", "size"))
   }
 )


### PR DESCRIPTION
Fix #15 